### PR TITLE
[Feat] Make archive expanding optional

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install dependencies.
-        run: pip3 install yamllint ansible-lint ansible "molecule[lint,docker]"
+        run: pip3 install yamllint ansible-lint ansible "molecule[lint,docker]" "molecule-plugins[docker]"
 
       - name: Install Galaxy dependencies.
         run: ansible-galaxy collection install community.docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Removed all default prerequisites which were (un)archiving tools. You now need to install them manually if needed.
 * Made the archive expansion optional. This should also include the case in which the release is a single executable file, not archived.
-* Renamed role from `mirceanton.downloader` to `mirceanton.release_installer`
+* Renamed some of the variables. :sweat_smile:
 
 ## v1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v2.0.0
+
+**:bomb: Breaking Changes**:
+
+* Removed all default prerequisites which were (un)archiving tools. You now need to install them manually if needed.
+* Made the archive expansion optional. This should also include the case in which the release is a single executable file, not archived.
+* Renamed role from `mirceanton.downloader` to `mirceanton.release_installer`
+
 ## v1.0.0
 
 * Initial release of the `mirceanton.downloader` role 🚀

--- a/README.md
+++ b/README.md
@@ -11,14 +11,16 @@ N/A
 Role Variables
 --------------
 
-|         Variable          |     Type     |              Default              |                           Description                            |
-| :-----------------------: | :----------: | :-------------------------------: | :--------------------------------------------------------------: |
-|    `downloader_prereq`    | list(string) | `[unzip, gzip, bzip2, xzip, tar]` |              List of archiving utilities required.               |
-| `downloader_archive_url`  |    string    |            `UNDEFINED`            |            Path or URL where the archive is located.             |
-| `downloader_archive_dest` |    string    |            `UNDEFINED`            | Path to where the archive should be downloaded and extracted to. |
-|   `downloader_exec_src`   |    string    |            `UNDEFINED`            |         Path at which to find the downloaded executable.         |
-|  `downloader_exec_dest`   |    string    |            `UNDEFINED`            |         Path at which to copy the downloaded executable.         |
-|  `downloader_exec_mode`   |    string    |              `0755`               |            Permissions for the downloaded executable.            |
+| Variable                             |   Type   |     Default      | Description                                                                                   |
+| :----------------------------------- | :------: | :--------------: | :-------------------------------------------------------------------------------------------- |
+| `downloader_download_url`            | `string` |      `N/A`       | The url to download.                                                                          |
+| `downloader_download_dest`           | `string` |      `/tmp`      | The path at which to download the given url.                                                  |
+| `downloader_download_validate_certs` |  `bool`  |      `true`      | Whether or not to validate the certificates for the download url.                             |
+| `downloader_unarchive`               |  `bool`  |     `false`      | Whether or not the downloaded file is an archive which needs to be expanded.                  |
+| `downloader_unarchive_dest`          | `string` |      `/tmp`      | The path at which to expand the archive. Required if `downloader_unarchive` is set to `true`. |
+| `downloader_executable_src`          | `string` |      `N/A`       | The path to the executable file which needs to be installed.                                  |
+| `downloader_executable_dest`         | `string` | `/usr/local/bin` | The path at which to move the executable file.                                                |
+| `downloader_executable_mode`         | `string` |      `0755`      | The permissions of the executable file.                                                       |
 
 Dependencies
 ------------
@@ -36,13 +38,24 @@ Installing the terraform package via the prebuilt binaries:
   beome: true
   gather_facts: true
 
-  roles:
-    - name: mirceanton.downloader
+  tasks:
+    - name: Install unzip
+      ansible.builtin.apt:
+        name: unzip
+        state: present
+        update_cache: true
+
+    - name: Include role
+      ansible.builtin.include_role:
+        name: mirceanton.downloader
       vars:
-        downloader_archive_url: https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_linux_amd64.zip
-        downloader_archive_dest: /tmp
-        downloader_exec_src: /tmp/terraform
-        downloader_exec_dest: /usr/bin/terraform
+        downloader_download_url: https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_linux_amd64.zip
+        downloader_download_dest: /tmp/terraform_1.3.3_linux_amd64.zip
+        downloader_unarchive: true
+        downloader_unarchive_dest: /tmp
+        downloader_executable_src: /tmp/terraform
+        downloader_executable_dest: /usr/bin/terraform
+        downloader_executable_mode: 0755
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,0 @@
----
-downloader_prereq:
-  - unzip
-  - gzip
-  - bzip2
-  - xzip
-  - tar

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
   author: Mircea-Pavel ANTON
   namespace: mirceanton
-  role_name: release_installer
+  role_name: downloader
   description: A role that install a binery from an archive.
   # company: N/A
 
@@ -12,7 +12,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - stretch   # 9
         - buster    # 10
         - bullseye  # 11
     - name: Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
   author: Mircea-Pavel ANTON
   namespace: mirceanton
-  role_name: downloader
+  role_name: release_installer
   description: A role that install a binery from an archive.
   # company: N/A
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,6 +6,7 @@
   vars:
     downloader_download_url: https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_linux_amd64.zip
     downloader_download_dest: /tmp/terraform_1.3.3_linux_amd64.zip
+    downloader_download_validate_certs: false
     downloader_unarchive: true
     downloader_unarchive_dest: /tmp
     downloader_executable_src: /tmp/terraform

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,12 +4,19 @@
   gather_facts: true
 
   vars:
-    downloader_archive_url: https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_linux_amd64.zip
-    downloader_archive_dest: /tmp/
+    release_installer_download_url: https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_linux_amd64.zip
+    release_installer_download_dest: /tmp/terraform_1.3.3_linux_amd64.zip
+    release_installer_unarchive: true
+    release_installer_unarchive_dest: /tmp/terraform
     downloader_exec_src: /tmp/terraform
     downloader_exec_dest: /usr/bin/terraform
 
   tasks:
-    - name: "Include mirceanton.downloader"
-      include_role:
-        name: "mirceanton.downloader"
+    - name: Install unzip
+      ansible.builtin.apt:
+        name: unzip
+        state: present
+
+    - name: Include role
+      ansible.builtin.include_role:
+        name: mirceanton.role_installer

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,16 +3,6 @@
   hosts: all
   gather_facts: true
 
-  vars:
-    downloader_download_url: https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_linux_amd64.zip
-    downloader_download_dest: /tmp/terraform_1.3.3_linux_amd64.zip
-    downloader_download_validate_certs: false
-    downloader_unarchive: true
-    downloader_unarchive_dest: /tmp
-    downloader_executable_src: /tmp/terraform
-    downloader_executable_dest: /usr/bin/terraform
-    downloader_executable_mode: '0755'
-
   tasks:
     - name: Install unzip
       ansible.builtin.apt:
@@ -23,3 +13,12 @@
     - name: Include role
       ansible.builtin.include_role:
         name: mirceanton.downloader
+      vars:
+        downloader_download_url: https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_linux_amd64.zip
+        downloader_download_dest: /tmp/terraform_1.3.3_linux_amd64.zip
+        downloader_download_validate_certs: false
+        downloader_unarchive: true
+        downloader_unarchive_dest: /tmp
+        downloader_executable_src: /tmp/terraform
+        downloader_executable_dest: /usr/bin/terraform
+        downloader_executable_mode: '0755'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,10 +4,10 @@
   gather_facts: true
 
   vars:
-    release_installer_download_url: https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_linux_amd64.zip
-    release_installer_download_dest: /tmp/terraform_1.3.3_linux_amd64.zip
-    release_installer_unarchive: true
-    release_installer_unarchive_dest: /tmp/terraform
+    downloader_download_url: https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_linux_amd64.zip
+    downloader_download_dest: /tmp/terraform_1.3.3_linux_amd64.zip
+    downloader_unarchive: true
+    downloader_unarchive_dest: /tmp
     downloader_exec_src: /tmp/terraform
     downloader_exec_dest: /usr/bin/terraform
 
@@ -16,7 +16,8 @@
       ansible.builtin.apt:
         name: unzip
         state: present
+        update_cache: true
 
     - name: Include role
       ansible.builtin.include_role:
-        name: mirceanton.role_installer
+        name: mirceanton.downloader

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,8 +8,9 @@
     downloader_download_dest: /tmp/terraform_1.3.3_linux_amd64.zip
     downloader_unarchive: true
     downloader_unarchive_dest: /tmp
-    downloader_exec_src: /tmp/terraform
-    downloader_exec_dest: /usr/bin/terraform
+    downloader_executable_src: /tmp/terraform
+    downloader_executable_dest: /usr/bin/terraform
+    downloader_executable_mode: '0755'
 
   tasks:
     - name: Install unzip

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,10 +17,10 @@ lint: |
   ansible-lint .
 
 platforms:
-  - name: Debian-9
-    image: antonmircea/debian-python:9
-    pre_build_image: true
-    privileged: true
+  # - name: Debian-9
+  #   image: antonmircea/debian-python:9
+  #   pre_build_image: true
+  #   privileged: true
   - name: Debian-10
     image: antonmircea/debian-python:10
     pre_build_image: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,12 +3,6 @@
   hosts: all
   gather_facts: true
 
-  vars:
-    downloader_archive_url: https://releases.hashicorp.com/terraform/1.3.3/terraform_1.3.3_linux_amd64.zip
-    downloader_archive_dest: /tmp/
-    downloader_exec_src: /tmp/terraform
-    downloader_exec_dest: /usr/bin/terraform
-
   tasks:
     - name: Check if commands are working
       ansible.builtin.command: "terraform --version"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
-- name: Install prerequisites
-  ansible.builtin.package:
-    name: "{{ item }}"
-  loop: "{{ downloader_prereq }}"
+- name: Download Release
+  ansible.builtin.get_url:
+    url: "{{ mri_download_url }}"
+    dest: "{{ mri_download_dest }}"
 
-- name: Download and Expand archive
+- name: Expand Archive
   ansible.builtin.unarchive:
-    src: "{{ downloader_archive_url }}"
-    dest: "{{ downloader_archive_dest }}"
+    src: "{{ mri_download_dest }}"
+    dest: "{{ mri_unarchive_dest }}"
     remote_src: yes
-    validate_certs: false
+  when: mri_unarchive | default(false)
 
-- name: Move executable
+- name: Install Release
   ansible.builtin.copy:
     remote_src: true
-    src: "{{ downloader_exec_src }}"
-    dest: "{{ downloader_exec_dest }}"
-    mode: "{{ downloader_exec_mode | default('755') }}"
+    src: "{{ mri_executable_src }}"
+    dest: "{{ mri_executable_dest }}"
+    mode: "{{ mri_executable_mode | default('0755') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
 - name: Download Release
   ansible.builtin.get_url:
-    url: "{{ mri_download_url }}"
-    dest: "{{ mri_download_dest }}"
+    url: "{{ release_installer_download_url }}"
+    dest: "{{ release_installer_download_dest }}"
 
 - name: Expand Archive
   ansible.builtin.unarchive:
-    src: "{{ mri_download_dest }}"
-    dest: "{{ mri_unarchive_dest }}"
+    src: "{{ release_installer_download_dest }}"
+    dest: "{{ release_installer_unarchive_dest }}"
     remote_src: yes
-  when: mri_unarchive | default(false)
+  when: release_installer_unarchive | default(false)
 
 - name: Install Release
   ansible.builtin.copy:
     remote_src: true
-    src: "{{ mri_executable_src }}"
-    dest: "{{ mri_executable_dest }}"
-    mode: "{{ mri_executable_mode | default('0755') }}"
+    src: "{{ release_installer_executable_src }}"
+    dest: "{{ release_installer_executable_dest }}"
+    mode: "{{ release_installer_executable_mode | default('0755') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,20 @@
 ---
 - name: Download Release
   ansible.builtin.get_url:
-    url: "{{ release_installer_download_url }}"
-    dest: "{{ release_installer_download_dest }}"
+    url: "{{ downloader_download_url }}"
+    dest: "{{ downloader_download_dest }}"
+    validate_certs: "{{ downloader_download_validate_certs | default(false) }}"
 
 - name: Expand Archive
   ansible.builtin.unarchive:
-    src: "{{ release_installer_download_dest }}"
-    dest: "{{ release_installer_unarchive_dest }}"
-    remote_src: yes
-  when: release_installer_unarchive | default(false)
+    src: "{{ downloader_download_dest }}"
+    dest: "{{ downloader_unarchive_dest }}"
+    remote_src: true
+  when: downloader_unarchive | default(false)
 
 - name: Install Release
   ansible.builtin.copy:
+    src: "{{ downloader_executable_src }}"
+    dest: "{{ downloader_executable_dest }}"
+    mode: "{{ downloader_executable_mode | default('0755') }}"
     remote_src: true
-    src: "{{ release_installer_executable_src }}"
-    dest: "{{ release_installer_executable_dest }}"
-    mode: "{{ release_installer_executable_mode | default('0755') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,18 +3,18 @@
   ansible.builtin.get_url:
     url: "{{ downloader_download_url }}"
     dest: "{{ downloader_download_dest }}"
-    validate_certs: "{{ downloader_download_validate_certs | default(false) }}"
+    validate_certs: "{{ downloader_download_validate_certs }}"
 
 - name: Expand Archive
   ansible.builtin.unarchive:
     src: "{{ downloader_download_dest }}"
     dest: "{{ downloader_unarchive_dest }}"
     remote_src: true
-  when: downloader_unarchive | default(false)
+  when: downloader_unarchive
 
 - name: Install Release
   ansible.builtin.copy:
     src: "{{ downloader_executable_src }}"
     dest: "{{ downloader_executable_dest }}"
-    mode: "{{ downloader_executable_mode | default('0755') }}"
+    mode: "{{ downloader_executable_mode }}"
     remote_src: true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,6 @@
+---
+downloader_download_validate_certs: true
+downloader_download_dest: /tmp
+downloader_unarchive: false
+downloader_unarchive_dest: /tmp
+downloader_executable_mode: '0755'


### PR DESCRIPTION
# Description

Make the archive expansion optional to cover the case in which the download url points to a single executable file (uncompressed).

## Developer Checklist

- [x] [Readme](../../README.md) is up to date
- [X] [CHANGELOG](../../CHANGELOG.md) is up to date
- [x] All tests (CI and/or manual) have passed

## Reviewer Checklist

- [X] [Readme](../../README.md) is up to date
- [x] [CHANGELOG](../../CHANGELOG.md) is up to date
- [x] All tests (CI and/or manual) have passed
- [X] Source and Target branches have been verified
- [X] `Squash and Merge` is selected as opposed to regular merge
- [X] Source branch has been removed after the merge
